### PR TITLE
Enable rating#10

### DIFF
--- a/app/controllers/profile/reviews_controller.rb
+++ b/app/controllers/profile/reviews_controller.rb
@@ -21,13 +21,23 @@ class Profile::ReviewsController < ApplicationController
 
   def disable
     review = Review.find(params[:id])
-    # user = User.find(review.user_id)
     order_item = OrderItem.find(review.order_item_id)
     order = Order.find(params[:order_id])
     review.status = false
     review.save
 
     flash[:notice] = "You disabled your review for #{order_item.item.name}!"
+    redirect_to profile_order_path(order)
+  end
+
+  def enable
+    review = Review.find(params[:id])
+    order_item = OrderItem.find(review.order_item_id)
+    order = Order.find(params[:order_id])
+    review.status = true
+    review.save
+
+    flash[:notice] = "You enabled your review for #{order_item.item.name}!"
     redirect_to profile_order_path(order)
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -43,9 +43,4 @@ class Item < ApplicationRecord
   def ever_ordered?
     OrderItem.find_by_item_id(self.id) !=  nil
   end
-
-  #
-  # def enabled_reviews
-  #   Review.where(status: true, item: self)
-  # end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -43,4 +43,8 @@ class Item < ApplicationRecord
   def ever_ordered?
     OrderItem.find_by_item_id(self.id) !=  nil
   end
+
+  def current_reviews
+    Review.where(status:true, order_item: self.order_items)
+  end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -19,5 +19,4 @@ class OrderItem < ApplicationRecord
   def review_description
     reviews.pluck(:description)[0]
   end
-
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -8,4 +8,8 @@ class Review < ApplicationRecord
     user.name
   end
 
+  def self.enabled_reviews(item)
+    where(status:true, order_item: item.order_items)
+  end
+
 end

--- a/app/views/items/_card.html.erb
+++ b/app/views/items/_card.html.erb
@@ -10,6 +10,7 @@
     <p>
       <strong>Sold by:</strong> <%= item.user.name %><br/>
       <strong>In stock:</strong> <%= item.inventory %>
+      <strong>Reviews:</strong> <%= item.current_reviews.count %>
     </p>
   </div>
 </div>

--- a/app/views/profile/orders/_order_item.html.erb
+++ b/app/views/profile/orders/_order_item.html.erb
@@ -9,13 +9,15 @@
     <p>Quantity: <%= oitem.quantity %></p>
     <p>Subtotal: <%= number_to_currency(oitem.subtotal) %></p>
     <p>Fulfilled: <%= oitem.fulfilled ? 'Yes' : 'No' %></p>
-    <p>Reviews: <%= oitem.reviews.count %></p>
+    <p>Reviews: <%= oitem.reviews.enabled_reviews(oitem.item).count %></p>
 
     <div id="oitem-<%= oitem.id %>-review">
     <% if @order.status == 'completed' && oitem.reviews.count == 0 %>
       <%= button_to "Leave Review", profile_order_order_item_new_review_path(@order, oitem), method: :get %>
     <% elsif @order.status == 'completed' && oitem.reviews.count == 1 && oitem.reviews[0].status %>
       <%= button_to "Disable Review", profile_order_order_item_disable_review_path(@order, oitem, oitem.reviews[0]), method: :patch %>
+    <% elsif @order.status == 'completed' && oitem.reviews.count == 1 && !oitem.reviews[0].status %>
+      <%= button_to "Enable Review", profile_order_order_item_enable_review_path(@order, oitem, oitem.reviews[0]), method: :patch %>
     <% end %>
     <p>Your review: <%= oitem.review_description %></p>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       get '/order_item/:order_item_id/review/new', to: 'reviews#new', as: 'order_item_new_review'
       post '/order_item/:order_item_id/review', to: 'reviews#create', as: 'order_item_reviews'
       patch '/order_item/:order_item_id/review/:id/disable', to: 'reviews#disable', as: 'order_item_disable_review'
+      patch '/order_item/:order_item_id/review/:id/enable', to: 'reviews#enable', as: 'order_item_enable_review'
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,7 +47,7 @@ order_item_8 = create(:order_item, order: order, item: item_3, price: 3, quantit
 order = create(:completed_order, user: user)
 order_item_9 = create(:fulfilled_order_item, order: order, item: item_1, price: 1, quantity: 1, created_at: rng.rand(4).days.ago, updated_at: rng.rand(59).minutes.ago)
 order_item_10 = create(:fulfilled_order_item, order: order, item: item_2, price: 2, quantity: 1, created_at: rng.rand(23).hour.ago, updated_at: rng.rand(59).minutes.ago)
-# 
-# Review.create(title: "yay", description: "great", rating: 4, item: item_1, user: user,  status: true)
-# Review.create(title: "no", description: "this was terrible", rating: 1, item: item_3, user: user,  status: false)
-# Review.create(title: "fabulous", description: "the best ever", rating: 5, item: item_2, user: user,  status: true)
+
+Review.create(title: "yay", description: "great", rating: 4, order_item: order_item_1, user: user,  status: true)
+Review.create(title: "no", description: "this was terrible", rating: 1, order_item: order_item_3, user: user,  status: false)
+Review.create(title: "fabulous", description: "the best ever", rating: 5, order_item: order_item_10, user: user,  status: true)

--- a/spec/features/user/user_can_enable_a_rating_spec.rb
+++ b/spec/features/user/user_can_enable_a_rating_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe 'as a user on an order show page when i have disabled a review' do
+  before(:each) do
+    @user = create(:user, name: "Mary")
+    @merchant = create(:merchant)
+    @item_1 = create(:item, user: @merchant)
+    @item_2 = create(:item, user: @merchant)
+    @yesterday = 1.day.ago
+    @order = create(:completed_order, user: @user)
+    @oi_1 = create(:fulfilled_order_item, order: @order, item: @item_1, price: 1, quantity: 1, created_at: @yesterday, updated_at: @yesterday)
+    @oi_2 = create(:fulfilled_order_item, order: @order, item: @item_2, price: 2, quantity: 1, created_at: @yesterday, updated_at: 2.hours.ago)
+    @review = Review.create(title: "yay", description: "great", rating: 4, order_item: @oi_1, user: @user, status: false)
+    @review_1 = Review.create(title: "hooray", description: "great", rating: 4, order_item: @oi_2, user: @user, status: true)
+  end
+  it 'sees a button to enable that review' do
+
+    visit profile_order_path(@order)
+
+    within "#oitem-#{@oi_2.id}-review" do
+      expect(page).to_not have_button('Enable Review')
+    end
+
+    within "#oitem-#{@oi_1.id}-review" do
+      expect(page).to have_button('Enable Review')
+    end
+  end
+  it 'clicks on the button and the review is shown again on the item show page' do
+    visit profile_order_path(@order)
+
+    within "#oitem-#{@oi_1.id}-review" do
+      click_button 'Enable Review'
+    end
+
+    expect(current_path).to eq(profile_order_path(@order))
+
+    expect(page).to have_content("You enabled your review for #{@oi_1.item.name}!")
+
+    visit item_path(@item_1)
+
+    within "#review-0" do
+      expect(page).to_not have_content('No reviews currently')
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@review.description)
+      expect(page).to have_content("Rating: #{@review.rating}")
+      expect(page).to have_content(@review.title)
+      expect(page).to have_link("Return to Orders")
+    end
+  end
+end
+
+
+
+
+
+
+
+
+# any disabled rating that a user sees on their order show page
+# can be enabled by clicking enable. this will add this review
+# to an item review count again and will be reflected it the total
+# reviews count on the index page as well as on the item show page.
+# after enabling, they will now see a 'disable' button.

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -66,5 +66,17 @@ RSpec.describe Item, type: :model do
       expect(item_1.ever_ordered?).to eq(true)
       expect(item_2.ever_ordered?).to eq(false)
     end
+    it '.current_reviews' do
+      user = create(:user, name: "Mary")
+      item = create(:item)
+      order = create(:completed_order)
+      oi_1 = create(:fulfilled_order_item, order: order, item: item, created_at: 4.days.ago, updated_at: 1.days.ago)
+      oi_3 = create(:fulfilled_order_item, order: order, item: item, created_at: 4.days.ago, updated_at: 1.days.ago)
+      review_2 = Review.create(title: "better", description: "fun", rating: 4, order_item: oi_1, user: user, status: false)
+      review_3 = Review.create(title: "better", description: "fun", rating: 4, order_item: oi_3, user: user)
+      reviews = ([review_3])
+
+      expect(item.current_reviews).to eq(reviews)
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Item, type: :model do
   describe 'relationships' do
     it { should belong_to :user }
     it { should have_many :order_items }
-    # it { should have_many :reviews }
     it { should have_many(:orders).through(:order_items) }
   end
 
@@ -67,18 +66,5 @@ RSpec.describe Item, type: :model do
       expect(item_1.ever_ordered?).to eq(true)
       expect(item_2.ever_ordered?).to eq(false)
     end
-
-    # it '.enabled_review' do
-    #   user = create(:user, name: "Mary")
-    #   item = create(:item)
-    #   item_2 = create(:item)
-    #   review = Review.create(title: "yay", description: "great", rating: 4, item: item, user: user)
-    #   review_2 = Review.create(title: "better", description: "fun", rating: 4, item: item, user: user, status: false)
-    #   review_3 = Review.create(title: "better", description: "fun", rating: 4, item: item_2, user: user)
-    #   user.reviews << review
-    #   final = item.enabled_reviews
-    #
-    #   expect(final).to eq([review])
-    # end
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -25,4 +25,25 @@ RSpec.describe Review, type: :model do
       expect(review.user_name).to eq(name)
     end
   end
+  describe 'Class Methods' do
+    it '#enabled_reviews' do
+      user = create(:user, name: "Mary")
+      item = create(:item)
+      item_2 = create(:item)
+      order = create(:completed_order)
+      oi_1 = create(:fulfilled_order_item, order: order, item: item, created_at: 4.days.ago, updated_at: 1.days.ago)
+      oi_2 = create(:fulfilled_order_item, order: order, item: item_2, created_at: 4.days.ago, updated_at: 1.days.ago)
+      oi_3 = create(:fulfilled_order_item, order: order, item: item, created_at: 4.days.ago, updated_at: 1.days.ago)
+      oi_4 = create(:fulfilled_order_item, order: order, item: item_2, created_at: 4.days.ago, updated_at: 1.days.ago)
+      review_2 = Review.create(title: "better", description: "fun", rating: 4, order_item: oi_1, user: user, status: false)
+      review_3 = Review.create(title: "better", description: "fun", rating: 4, order_item: oi_3, user: user)
+      review_4 = Review.create(title: "better", description: "fun", rating: 4, order_item: oi_2, user: user, status: false)
+      review_5 = Review.create(title: "better", description: "fun", rating: 4, order_item: oi_4, user: user)
+      final = Review.enabled_reviews(item)
+      final_2 = Review.enabled_reviews(item_2)
+
+      expect(final).to eq([review_3])
+      expect(final_2).to eq([review_5])
+    end
+  end
 end


### PR DESCRIPTION
tests passing, 100% coverage
closes #10 
any disabled rating that a user sees on their order show page can be enabled by clicking enable. this will add this review to an item review count again and will be reflected it the total reviews count on the index page as well as on the item show page. after enabling, they will now see a 'disable' button.